### PR TITLE
iterrogate AmeisenBot object for null prior to iteration

### DIFF
--- a/AmeisenBotX/ConfigEditorWindow.xaml.cs
+++ b/AmeisenBotX/ConfigEditorWindow.xaml.cs
@@ -535,16 +535,17 @@ namespace AmeisenBotX
             // Idle Actions
             IdleActionItems = new();
 
-            foreach (IIdleAction x in AmeisenBot.Bot.IdleActions.IdleActions)
-            {
-                bool state = Config.IdleActionsEnabled.TryGetValue(x.ToString(), out bool b) && b;
-
-                IdleActionItems.Add(new()
+            if (AmeisenBot?.Bot.IdleActions.IdleActions != null)
+                foreach (IIdleAction x in AmeisenBot.Bot.IdleActions.IdleActions)
                 {
-                    Name = x.ToString(),
-                    IsEnabled = state
-                });
-            }
+                    bool state = Config.IdleActionsEnabled.TryGetValue(x.ToString(), out bool b) && b;
+
+                    IdleActionItems.Add(new()
+                    {
+                        Name = x.ToString(),
+                        IsEnabled = state
+                    });
+                }
 
             listviewIdleActions.ItemsSource = IdleActionItems;
 


### PR DESCRIPTION
would fix #105 

on new conf AmesenBot object is null when ConfigEditorWindow is spawned.  check for null prior to iteration through IdleActions.

probably a temporary fix;  long term may not want to work with the Bot objects at all during LoadConfigToUi, but up to you.